### PR TITLE
Remove placeholder content on protocol reference

### DIFF
--- a/docs/reference/protocol/index.md
+++ b/docs/reference/protocol/index.md
@@ -6,54 +6,6 @@ prev: false
 # Protocol Reference
 
 > [!CAUTION]
-> This section of the documentation is still being written. The text below is for testing purposes.
+> This section of the documentation is still being written.
 
-This page demonstrates usage of some of the runtime APIs provided by VitePress.
-
-The main `useData()` API can be used to access site, theme, and page data for the current page. It works in both `.md` and `.vue` files:
-
-```md
-<script setup>
-import { useData } from 'vitepress'
-
-const { theme, page, frontmatter } = useData()
-</script>
-
-## Results
-
-### Theme Data
-
-<pre>{{ theme }}</pre>
-
-### Page Data
-
-<pre>{{ page }}</pre>
-
-### Page Frontmatter
-
-<pre>{{ frontmatter }}</pre>
-```
-
-<script setup>
-import { useData } from 'vitepress'
-
-const { site, theme, page, frontmatter } = useData()
-</script>
-
-## Results
-
-### Theme Data
-
-<pre>{{ theme }}</pre>
-
-### Page Data
-
-<pre>{{ page }}</pre>
-
-### Page Frontmatter
-
-<pre>{{ frontmatter }}</pre>
-
-## More
-
-Check out the documentation for the [full list of runtime APIs](https://vitepress.dev/reference/runtime-api#usedata).
+This page will eventually document the full FIRES protocol, but the text is still being rewritten based on the feedback given by reviewers of the FIRES proposal document which was originally written in September/October 2023.


### PR DESCRIPTION
There's no longer need for the original demo content now I know my way around Vitepress.