### PR TITLE
Change 'Getting Started' link to 'Project Background'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ hero:
       text: Learn the Concepts
       link: /concepts/
     - theme: alt
-      text: Getting Started
-      link: /manuals/reference-server/
+      text: Project Background
+      link: /concepts/background/
 
 features:
   - title: Only provides advisories and recommendations


### PR DESCRIPTION
As that's more helpful right now that the non-existent reference server "getting started" page