### PR TITLE
Fix: Improve navigation around WIP sections

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,6 +59,10 @@ export default withMermaid({
         text: "Manuals",
         items: [
           {
+            text: "Under Development!",
+            link: "/manuals/",
+          },
+          /* {
             text: "Reference Server",
             link: "/manuals/reference-server/",
           },
@@ -70,6 +74,7 @@ export default withMermaid({
             text: "Example Consumer",
             link: "/manuals/example-consumer/",
           },
+          */
         ],
       },
     ],
@@ -158,7 +163,12 @@ export default withMermaid({
         },
       ],
 
-      "/manuals/reference-server": [
+      "/manuals/": [
+        {
+          text: "Manuals",
+          link: "/manuals/",
+          items: [],
+        },
         {
           text: "Reference Server",
           items: [
@@ -168,8 +178,6 @@ export default withMermaid({
             },
           ],
         },
-      ],
-      "/manuals/example-provider": [
         {
           text: "Example Provider",
           items: [
@@ -179,8 +187,6 @@ export default withMermaid({
             },
           ],
         },
-      ],
-      "/manuals/example-consumer": [
         {
           text: "Example Consumer",
           items: [

--- a/docs/manuals/index.md
+++ b/docs/manuals/index.md
@@ -1,0 +1,6 @@
+# Manuals
+
+Once the initial implementation of the Reference Server is underway or complete, we'll have a set of manuals available for running the [reference server](./reference-server/index.md), and the two examples of a [provider](./example-provider/index.md) and [consumer](./example-consumer/index.md).
+
+> [!CAUTION]
+> This section of the documentation is still being written

--- a/docs/reference/testing/index.md
+++ b/docs/reference/testing/index.md
@@ -4,7 +4,7 @@ next: false
 
 # Conformance Tests
 
-As FIRES is both a protocol and reference server implementation, we're working on a comprehensive suite of conformance tests, such that anyone wishing to implement the FIRES protocol can assert that they are implementing it correctly.
-
 > [!CAUTION]
 > This section of the documentation is still being written
+
+As FIRES is both a protocol and reference server implementation, we're working on a comprehensive suite of conformance tests, such that anyone wishing to implement the FIRES protocol can assert that they are implementing it correctly.


### PR DESCRIPTION
This removes the individual items from the Manuals menu in favour of a single section that initially explains it's a WIP.