### PR TITLE
Add PUBLIC_URL environment variable

### DIFF
--- a/.changeset/lovely-buckets-decide.md
+++ b/.changeset/lovely-buckets-decide.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Add required PUBLIC_URL environment variable

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -67,6 +67,7 @@ jobs:
       NODE_ENV: development
       PORT: 4444
       HOST: localhost
+      PUBLIC_URL: http://localhost:4444/
       LOG_LEVEL: info
       APP_KEY: "test_determinist_key_DO_NOT_USE_IN_PRODUCTION"
       DATABASE_HOST: 127.0.0.1

--- a/components/fires-server/.env.docker
+++ b/components/fires-server/.env.docker
@@ -1,5 +1,8 @@
 PORT=4444
 
+# Assuming the docker container is mapped to the same port on the host machine
+PUBLIC_URL=http://localhost:$PORT/
+
 LOG_LEVEL=trace
 
 # You can generate an APP_KEY with: `node ace generate:key` or `openssl rand -hex 32`

--- a/components/fires-server/.env.example
+++ b/components/fires-server/.env.example
@@ -3,6 +3,7 @@ NODE_ENV=development
 
 PORT=4444
 HOST=localhost
+PUBLIC_URL=http://$HOST:$PORT/
 
 LOG_LEVEL=info
 

--- a/components/fires-server/start/env.ts
+++ b/components/fires-server/start/env.ts
@@ -22,6 +22,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   */
   PORT: Env.schema.number(),
   HOST: Env.schema.string({ format: 'host' }),
+  PUBLIC_URL: Env.schema.string({ format: 'url', tld: false }),
 
   /*
   |----------------------------------------------------------

--- a/components/fires-server/start/logging.ts
+++ b/components/fires-server/start/logging.ts
@@ -1,7 +1,13 @@
 import emitter from '@adonisjs/core/services/emitter'
+import logger from '@adonisjs/core/services/logger'
+import env from '#start/env'
 
 const NS_PER_SEC = 1e9
 const MS_PER_SEC = 1e6
+
+emitter.on('http:server_ready', () => {
+  logger.info(`Server available at: ${env.get('PUBLIC_URL')}`)
+})
 
 emitter.on('http:request_completed', ({ ctx, duration }) => {
   const { request, response } = ctx

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
   "scripts": {
+    "changeset": "changeset",
     "ci:version": "changeset version && prettier --write CHANGELOG.md && git add package.json CHANGELOG.md",
     "ci:release": "changeset publish",
     "local:publish": "op run --env-file=.env.local -- changeset version"


### PR DESCRIPTION
This will be used when constructing absolute URLs in JSON-LD responses. In the future, we may add support for alternative URLs as well as validating the request is from the public URL, but that isn't decided yet.

This takes care of the `public_url` setting from #42 