### PR TITLE
Add localisation support to the fires reference server

### DIFF
--- a/.changeset/silent-crabs-guess.md
+++ b/.changeset/silent-crabs-guess.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Add localisation support

--- a/components/fires-server/.env.example
+++ b/components/fires-server/.env.example
@@ -16,3 +16,6 @@ DATABASE_USER=fires
 DATABASE_PASSWORD=some-long-password
 # Optional: defaults to fires_<NODE_ENV>
 # DATABASE_DATABASE=fires_production
+
+# Optional, defaults to `en`
+# DEFAULT_LOCALE=en

--- a/components/fires-server/adonisrc.ts
+++ b/components/fires-server/adonisrc.ts
@@ -3,6 +3,19 @@ import { defineConfig } from '@adonisjs/core/app'
 export default defineConfig({
   /*
   |--------------------------------------------------------------------------
+  | Directories
+  |--------------------------------------------------------------------------
+  |
+  | These override some of the default directories for things in Adonis.js,
+  | such as where the language files are stored.
+  |
+  */
+  directories: {
+    languageFiles: 'resources/locales',
+  },
+
+  /*
+  |--------------------------------------------------------------------------
   | Commands
   |--------------------------------------------------------------------------
   |
@@ -35,6 +48,7 @@ export default defineConfig({
     () => import('@adonisjs/vite/vite_provider'),
     () => import('@adonisjs/core/providers/edge_provider'),
     () => import('@adonisjs/shield/shield_provider'),
+    () => import('@adonisjs/i18n/i18n_provider'),
     () => import('@thisismissem/adonisjs-respond-with/provider'),
   ],
 
@@ -50,6 +64,7 @@ export default defineConfig({
     () => import('#start/logging'),
     () => import('#start/routes'),
     () => import('#start/kernel'),
+    () => import('#start/events'),
   ],
 
   /*
@@ -84,6 +99,10 @@ export default defineConfig({
     },
     {
       pattern: 'resources/views/**/*.edge',
+      reloadServer: false,
+    },
+    {
+      pattern: 'resources/locales/**/*.{json,yaml,yml}',
       reloadServer: false,
     },
   ],

--- a/components/fires-server/app/listeners/localization.ts
+++ b/components/fires-server/app/listeners/localization.ts
@@ -1,0 +1,8 @@
+import logger from '@adonisjs/core/services/logger'
+import { MissingTranslationEventPayload } from '@adonisjs/i18n/types'
+
+export default class Localization {
+  handleMissing(event: MissingTranslationEventPayload) {
+    logger.error(`i18n error: missing ${event.locale} translation for: ${event.identifier}`, event)
+  }
+}

--- a/components/fires-server/app/middleware/localization_middleware.ts
+++ b/components/fires-server/app/middleware/localization_middleware.ts
@@ -1,0 +1,74 @@
+import { I18n } from '@adonisjs/i18n'
+import i18nManager from '@adonisjs/i18n/services/main'
+import type { NextFn } from '@adonisjs/core/types/http'
+import { type HttpContext, RequestValidator } from '@adonisjs/core/http'
+
+/**
+ * The "LocalizationMiddleware" middleware uses i18n service to share
+ * a request specific i18n object with the HTTP Context
+ */
+export default class LocalizationMiddleware {
+  /**
+   * Using i18n for validation messages. Applicable to only
+   * "request.validateUsing" method calls
+   */
+  static {
+    RequestValidator.messagesProvider = (ctx) => {
+      return ctx.i18n.createMessagesProvider()
+    }
+  }
+
+  /**
+   * This method reads the user language from the "Accept-Language"
+   * header and returns the best matching locale by checking it
+   * against the supported locales.
+   *
+   * Feel free to use different mechanism for finding user language.
+   */
+  protected getRequestLocale(ctx: HttpContext) {
+    const userLanguages = ctx.request.languages()
+    return i18nManager.getSupportedLocaleFor(userLanguages)
+  }
+
+  async handle(ctx: HttpContext, next: NextFn) {
+    /**
+     * Finding user language
+     */
+    const language = this.getRequestLocale(ctx)
+
+    /**
+     * Assigning i18n property to the HTTP context
+     */
+    ctx.i18n = i18nManager.locale(language ?? i18nManager.defaultLocale)
+
+    /**
+     * Binding I18n class to the request specific instance of it.
+     * Doing so will allow IoC container to resolve an instance
+     * of request specific i18n object when I18n class is
+     * injected somewhere.
+     */
+    ctx.containerResolver.bindValue(I18n, ctx.i18n)
+
+    /**
+     * Sharing request specific instance of i18n with edge
+     * templates.
+     *
+     * Remove the following block of code, if you are not using
+     * edge templates.
+     */
+    if ('view' in ctx) {
+      ctx.view.share({ i18n: ctx.i18n })
+    }
+
+    return next()
+  }
+}
+
+/**
+ * Notify TypeScript about i18n property
+ */
+declare module '@adonisjs/core/http' {
+  export interface HttpContext {
+    i18n: I18n
+  }
+}

--- a/components/fires-server/config/i18n.ts
+++ b/components/fires-server/config/i18n.ts
@@ -1,0 +1,26 @@
+import app from '@adonisjs/core/services/app'
+import { defineConfig, formatters, loaders } from '@adonisjs/i18n'
+import env from '#start/env'
+
+const i18nConfig = defineConfig({
+  defaultLocale: env.get('DEFAULT_LOCALE', 'en'),
+
+  formatter: formatters.icu(),
+
+  loaders: [
+    /**
+     * The fs loader will read translations from the
+     * "resources/locales" directory.
+     *
+     * Each subdirectory represents a locale. For example:
+     *   - "resources/locales/en"
+     *   - "resources/locales/fr"
+     *   - "resources/locales/it"
+     */
+    loaders.fs({
+      location: app.languageFilesPath(),
+    }),
+  ],
+})
+
+export default i18nConfig

--- a/components/fires-server/package.json
+++ b/components/fires-server/package.json
@@ -59,6 +59,7 @@
     "@adonisjs/auth": "^9.3.1",
     "@adonisjs/core": "^6.17.2",
     "@adonisjs/cors": "^2.2.1",
+    "@adonisjs/i18n": "^2.2.0",
     "@adonisjs/lucid": "^21.6.0",
     "@adonisjs/shield": "^8.1.2",
     "@adonisjs/static": "^1.1.1",

--- a/components/fires-server/resources/views/about/index.edge
+++ b/components/fires-server/resources/views/about/index.edge
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ i18n.locale }}">
   <head>
     <meta charset="utf-8" />
     <title>

--- a/components/fires-server/start/env.ts
+++ b/components/fires-server/start/env.ts
@@ -48,4 +48,5 @@ export default await Env.create(new URL('../', import.meta.url), {
   | Variables for configuring the FIRES server
   |----------------------------------------------------------
   */
+  DEFAULT_LOCALE: Env.schema.string.optional(),
 })

--- a/components/fires-server/start/events.ts
+++ b/components/fires-server/start/events.ts
@@ -1,0 +1,3 @@
+import emitter from '@adonisjs/core/services/emitter'
+
+emitter.on('i18n:missing:translation', [() => import('#listeners/localization'), 'handleMissing'])

--- a/components/fires-server/start/kernel.ts
+++ b/components/fires-server/start/kernel.ts
@@ -38,6 +38,7 @@ server.use([
 router.use([
   () => import('@adonisjs/shield/shield_middleware'),
   () => import('@adonisjs/core/bodyparser_middleware'),
+  () => import('#middleware/localization_middleware'),
 ])
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,18 +33,21 @@ importers:
       '@adonisjs/cors':
         specifier: ^2.2.1
         version: 2.2.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))
+      '@adonisjs/i18n':
+        specifier: ^2.2.0
+        version: 2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1)
       '@adonisjs/lucid':
         specifier: ^21.6.0
         version: 21.6.0(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(luxon@3.5.0)(pg@8.13.3)
       '@adonisjs/shield':
         specifier: ^8.1.2
-        version: 8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)
+        version: 8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)
       '@adonisjs/static':
         specifier: ^1.1.1
         version: 1.1.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))
       '@adonisjs/vite':
         specifier: ^4.0.0
-        version: 4.0.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(edge.js@6.2.1)(vite@6.2.0(@types/node@22.13.5))
+        version: 4.0.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(edge.js@6.2.1)(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))
       '@picocss/pico':
         specifier: ^2.0.6
         version: 2.0.6
@@ -126,7 +129,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.1.1
-        version: 6.2.0(@types/node@22.13.5)
+        version: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
 
   docs:
     devDependencies:
@@ -141,10 +144,10 @@ importers:
         version: 4.34.9
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.5)
+        version: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
       vitepress:
         specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3(@algolia/client-search@5.20.4)(@types/node@22.13.5)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 2.0.0-alpha.3(@algolia/client-search@5.20.4)(@types/node@22.13.5)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.7.3)(yaml@2.7.0)
 
 packages:
 
@@ -281,6 +284,19 @@ packages:
       '@adonisjs/events': ^9.0.0
       '@adonisjs/fold': ^10.0.1
       '@adonisjs/logger': ^6.0.1
+
+  '@adonisjs/i18n@2.2.0':
+    resolution: {integrity: sha512-rZ5l3+Q9/ZG9pJVRhcs8ays9m8M3AxDeT8os/oTq3XU5qR46v4J3MQQbGMhsXwINXNohNAGaYjyDcBjGPnIbUA==}
+    engines: {node: '>=18.16.0'}
+    peerDependencies:
+      '@adonisjs/core': ^6.6.0
+      '@vinejs/vine': ^2.0.0 || ^3.0.0
+      edge.js: ^6.0.2
+    peerDependenciesMeta:
+      '@vinejs/vine':
+        optional: true
+      edge.js:
+        optional: true
 
   '@adonisjs/logger@6.0.6':
     resolution: {integrity: sha512-r5mLmmklSezzu3cu9QaXle2/gPNrgKpiIo+utYlwV3ITsW5JeIX/xcwwMTNM/9f1zU+SwOj5NccPTEFD3feRaw==}
@@ -785,6 +801,21 @@ packages:
     resolution: {integrity: sha512-3qbjLv+fzuuCg3umxc9/7YjrEXNaKwHgmig949nfyaTx8eL4FAsvFbu+1JcFUj1YAXofhaDn6JdEUBTYuk0Ssw==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
+  '@formatjs/ecma402-abstract@2.3.3':
+    resolution: {integrity: sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==}
+
+  '@formatjs/fast-memoize@2.2.6':
+    resolution: {integrity: sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==}
+
+  '@formatjs/icu-messageformat-parser@2.11.1':
+    resolution: {integrity: sha512-o0AhSNaOfKoic0Sn1GkFCK4MxdRsw7mPJ5/rBpIqdvcC7MIuyUSW8WChUEvrK78HhNpYOgqCQbINxCTumJLzZA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.13':
+    resolution: {integrity: sha512-N/LIdTvVc1TpJmMt2jVg0Fr1F7Q1qJPdZSCs19unMskCmVQ/sa0H9L8PWt13vq+gLdLg1+pPsvBLydL1Apahjg==}
+
+  '@formatjs/intl-localematcher@0.6.0':
+    resolution: {integrity: sha512-4rB4g+3hESy1bHSBG3tDFaMY2CH67iT7yne1e+0CLTsGLDcmoEWWpJjjpWVaYgYfYuohIRuo0E+N536gd2ZHZA==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -945,6 +976,10 @@ packages:
 
   '@poppinss/inspect@1.0.1':
     resolution: {integrity: sha512-kLeEaBSGhlleyYvKc7c9s3uE6xv7cwyulE0EgHf4jU/CL96h0yC4mkdw1wvC1l1PYYQozCGy46FwMBAAMOobCA==}
+
+  '@poppinss/intl-formatter@3.0.4':
+    resolution: {integrity: sha512-rupKdcMOneVHLFOX9XwFffuqocTpG61RFJU5Pyr6SpumrQOZORJ8OBoT1kBs0ZXwhAmG6gsXvVs1s9gRyQBmcg==}
+    engines: {node: '>=18.16.0'}
 
   '@poppinss/macroable@1.0.4':
     resolution: {integrity: sha512-ct43jurbe7lsUX5eIrj4ijO3j/6zIPp7CDnFWXDs7UPAbw1Pu1iH3oAmFdP4jcskKJBURH5M9oTtyeiUXyHX8Q==}
@@ -1807,6 +1842,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -2101,6 +2139,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-equals@3.0.3:
+    resolution: {integrity: sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2401,6 +2442,9 @@ packages:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
 
+  intl-messageformat@10.7.15:
+    resolution: {integrity: sha512-LRyExsEsefQSBjU2p47oAheoKz+EOJxSLDdjOaEjdriajfHsMXOmV/EhMvYSg9bAgCUHasuAC+mcUBe/95PfIg==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2655,6 +2699,9 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
+  micro-memoize@4.1.3:
+    resolution: {integrity: sha512-DzRMi8smUZXT7rCGikRwldEh6eO6qzKiPPopcr1+2EY3AYKpy5fu159PKWwIS9A6IWnrvPKDMcuFtyrroZa8Bw==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
@@ -2729,6 +2776,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  moize@6.1.6:
+    resolution: {integrity: sha512-vSKdIUO61iCmTqhdoIDrqyrtp87nWZUmBPniNjO0fX49wEYmyDO4lvlnFXiGcaH1JLE/s/9HbiK4LSHsbiUY6Q==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -2756,6 +2806,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   node-fetch@2.7.0:
@@ -3761,6 +3815,11 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4007,6 +4066,19 @@ snapshots:
       vary: 1.1.2
       youch: 3.3.4
 
+  '@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1)':
+    dependencies:
+      '@adonisjs/core': 6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1)
+      '@poppinss/intl-formatter': 3.0.4
+      '@poppinss/utils': 6.9.2
+      intl-messageformat: 10.7.15
+      luxon: 3.5.0
+      negotiator: 1.0.0
+      yaml: 2.7.0
+    optionalDependencies:
+      '@vinejs/vine': 3.0.0
+      edge.js: 6.2.1
+
   '@adonisjs/logger@6.0.6':
     dependencies:
       '@poppinss/utils': 6.9.2
@@ -4069,7 +4141,7 @@ snapshots:
       '@japa/api-client': 3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0)
       edge.js: 6.2.1
 
-  '@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)':
+  '@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)':
     dependencies:
       '@adonisjs/core': 6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1)
       '@adonisjs/session': 7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)
@@ -4077,6 +4149,7 @@ snapshots:
       csrf: 3.1.0
       helmet-csp: 3.4.0
     optionalDependencies:
+      '@adonisjs/i18n': 2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1)
       '@japa/api-client': 3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0)
       edge.js: 6.2.1
 
@@ -4089,16 +4162,16 @@ snapshots:
 
   '@adonisjs/tsconfig@1.4.0': {}
 
-  '@adonisjs/vite@4.0.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(edge.js@6.2.1)(vite@6.2.0(@types/node@22.13.5))':
+  '@adonisjs/vite@4.0.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/shield@8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(edge.js@6.2.1)(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))':
     dependencies:
       '@adonisjs/core': 6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1)
       '@poppinss/utils': 6.9.2
-      '@vavite/multibuild': 5.1.0(vite@6.2.0(@types/node@22.13.5))
+      '@vavite/multibuild': 5.1.0(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))
       edge-error: 4.0.2
-      vite: 6.2.0(@types/node@22.13.5)
-      vite-plugin-restart: 0.4.2(vite@6.2.0(@types/node@22.13.5))
+      vite: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
+      vite-plugin-restart: 0.4.2(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))
     optionalDependencies:
-      '@adonisjs/shield': 8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)
+      '@adonisjs/shield': 8.1.2(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/i18n@2.2.0(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@adonisjs/session@7.5.1(@adonisjs/core@6.17.2(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@3.0.0)(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1))(@japa/api-client@3.0.3(@japa/assert@4.0.1(@japa/runner@4.2.0))(@japa/runner@4.2.0))(edge.js@6.2.1)
       edge.js: 6.2.1
 
   '@algolia/autocomplete-core@1.17.9(@algolia/client-search@5.20.4)(algoliasearch@5.20.4)(search-insights@2.17.3)':
@@ -4565,6 +4638,32 @@ snapshots:
 
   '@faker-js/faker@9.5.0': {}
 
+  '@formatjs/ecma402-abstract@2.3.3':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/intl-localematcher': 0.6.0
+      decimal.js: 10.5.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.6':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.1':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.3
+      '@formatjs/icu-skeleton-parser': 1.8.13
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.13':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.3
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -4745,6 +4844,10 @@ snapshots:
   '@poppinss/hooks@7.2.5': {}
 
   '@poppinss/inspect@1.0.1': {}
+
+  '@poppinss/intl-formatter@3.0.4':
+    dependencies:
+      moize: 6.1.6
 
   '@poppinss/macroable@1.0.4': {}
 
@@ -5128,12 +5231,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vavite/multibuild@5.1.0(vite@6.2.0(@types/node@22.13.5))':
+  '@vavite/multibuild@5.1.0(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))':
     dependencies:
       '@types/node': 18.19.76
       cac: 6.7.14
       picocolors: 1.1.1
-      vite: 6.2.0(@types/node@22.13.5)
+      vite: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
 
   '@vinejs/compiler@3.0.0': {}
 
@@ -5148,9 +5251,9 @@ snapshots:
       normalize-url: 8.0.1
       validator: 13.12.0
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.2.0(@types/node@22.13.5))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 6.2.0(@types/node@22.13.5)
+      vite: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vue/compiler-core@3.5.13':
@@ -5563,6 +5666,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.5.0: {}
+
   decode-uri-component@0.2.2: {}
 
   dedent@1.5.3: {}
@@ -5875,6 +5980,8 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
+  fast-equals@3.0.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6178,6 +6285,13 @@ snapshots:
 
   interpret@2.2.0: {}
 
+  intl-messageformat@10.7.15:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.3
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/icu-messageformat-parser': 2.11.1
+      tslib: 2.8.1
+
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
@@ -6394,6 +6508,8 @@ snapshots:
 
   methods@1.1.2: {}
 
+  micro-memoize@4.1.3: {}
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
@@ -6452,6 +6568,11 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  moize@6.1.6:
+    dependencies:
+      fast-equals: 3.0.3
+      micro-memoize: 4.1.3
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -6467,6 +6588,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -7353,12 +7476,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-restart@0.4.2(vite@6.2.0(@types/node@22.13.5)):
+  vite-plugin-restart@0.4.2(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0)):
     dependencies:
       micromatch: 4.0.8
-      vite: 6.2.0(@types/node@22.13.5)
+      vite: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
 
-  vite@6.2.0(@types/node@22.13.5):
+  vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -7366,8 +7489,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.5
       fsevents: 2.3.3
+      yaml: 2.7.0
 
-  vitepress@2.0.0-alpha.3(@algolia/client-search@5.20.4)(@types/node@22.13.5)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.7.3):
+  vitepress@2.0.0-alpha.3(@algolia/client-search@5.20.4)(@types/node@22.13.5)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@docsearch/css': 3.9.0
       '@docsearch/js': 3.9.0(@algolia/client-search@5.20.4)(search-insights@2.17.3)
@@ -7375,7 +7499,7 @@ snapshots:
       '@shikijs/core': 3.1.0
       '@shikijs/transformers': 3.1.0
       '@shikijs/types': 3.1.0
-      '@vitejs/plugin-vue': 5.2.1(vite@6.2.0(@types/node@22.13.5))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@6.2.0(@types/node@22.13.5)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.2
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.8.2(typescript@5.7.3)
@@ -7384,7 +7508,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.2
       shiki: 3.1.0
-      vite: 6.2.0(@types/node@22.13.5)
+      vite: 6.2.0(@types/node@22.13.5)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.3
@@ -7464,6 +7588,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.7.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
This uses the built-in localization and internationalization support from Adonis.js, however, has an environment variable for the `DEFAULT_LOCALE`, which will specific the default locale on labels in the FIRES server.

These are standard ICU localizations files, though some localized data is stored in the database where appropriate.