### PR TITLE
Fix docker image labels by setting annotations levels

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -165,6 +165,8 @@ jobs:
           flavor: ${{ inputs.flavor }}
           tags: ${{ inputs.tags }}
           labels: ${{ inputs.labels }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
This is based on the documentation at:
- https://github.com/docker/metadata-action?tab=readme-ov-file#annotations
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images

Which suggests the annotations should be used for multi-arch images, and that the index alone may not have enough annotations, so to fetch from the manifest as well.