### PR TITLE
Fix docker image labels by setting annotations levels for pushing the multi-arch image

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -170,6 +170,8 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         run: |
           echo "$PUSH_TO_IMAGES" | xargs -I{} \
             docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \


### PR DESCRIPTION
I may have had the change in #53 in the wrong place. Trying in here instead.