### PR TITLE
Upgrade to pnpm 10.6.2 and apply changes for the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,7 @@ RUN \
   echo "${TZ}" > /etc/localtime; \
   # Creates fires user/group and sets home directory
   addgroup -Sg "${GID}" fires; \
-  adduser -S -u "${UID}" -h /opt/fires fires fires; \
-  # Creates /fires symlink to /opt/fires
-  ln -s /opt/fires /fires;
+  adduser -S -u "${UID}" -h /opt/fires fires fires;
 
 # Set /opt/mastodon as working directory
 WORKDIR /opt/fires
@@ -102,10 +100,10 @@ RUN pnpm run --filter=@fedimod/fires-server -r build
 RUN pnpm deploy --filter=@fedimod/fires-server --prod /fires-server-deploy
 
 FROM node AS fires-server
-COPY --from=build /opt/fires/components/fires-server/build /opt/fires/fires-server/
-COPY --from=build /fires-server-deploy/pnpm-lock.yaml /fires-server-deploy/package.json /opt/fires/fires-server/
-COPY --from=build /fires-server-deploy/node_modules /opt/fires/fires-server/node_modules/
-WORKDIR /opt/fires/fires-server/
+COPY --from=build /opt/fires/components/fires-server/build /opt/fires-server/
+COPY --from=build /fires-server-deploy/pnpm-lock.yaml /fires-server-deploy/package.json /opt/fires-server/
+COPY --from=build /fires-server-deploy/node_modules /opt/fires-server/node_modules/
+WORKDIR /opt/fires-server/
 USER fires
 EXPOSE 4444
 

--- a/components/fires-server/.env.docker
+++ b/components/fires-server/.env.docker
@@ -1,7 +1,7 @@
 PORT=4444
 
 # Assuming the docker container is mapped to the same port on the host machine
-PUBLIC_URL=http://localhost:$PORT/
+PUBLIC_URL=http://localhost:4444/
 
 LOG_LEVEL=trace
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fedimod/fires",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b",
   "scripts": {
     "changeset": "changeset",
     "ci:version": "changeset version && prettier --write CHANGELOG.md && git add package.json CHANGELOG.md",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
-  - "docs"
-  - "components/*"
+  - docs
+  - components/*
+onlyBuiltDependencies:
+  - "@swc/core"
+  - esbuild


### PR DESCRIPTION
pnpm 10.6.2 enables us to remove the hack around needing to reconstruct the `package.json` in the dockerfile, as they fixed the bug with the missing imports key: https://github.com/pnpm/pnpm/issues/9193

Theoretically, we could also move the contents of `.npmrc` to `pnpm-workspace.yaml` but the schema store version of the schema for the pnpm-workspace.yaml file hasn't yet been updated for pnpm 10.6.2: https://github.com/SchemaStore/schemastore