### PR TITLE
Use `DATABASE_URL` in libpq compat mode for database connections for better SSL handling

### DIFF
--- a/.changeset/three-cobras-rhyme.md
+++ b/.changeset/three-cobras-rhyme.md
@@ -1,0 +1,11 @@
+---
+"@fedimod/fires-server": minor
+---
+
+Use `DATABASE_URL` in libpq compat mode for database connections
+
+This change removes the previous `DATABASE_*` environment variables, and replaces them with a singular `DATABASE_URL`. This ensures we have better handling of SSL Certificates for self-signed certificates (e.g., when the postgresql database is on a managed service like DigitalOcean).
+
+When using `DATABASE_URL` you can omit the database name (the path component of the connection string), in which case, we will automatically use the combined of `fires_` and the current `NODE_ENV` as the database name.
+
+Also introduced is `DATABASE_POOL_MAX` to configure the database pool size, as we weren't previously using database connection pooling.

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     paths:
+      - ".github/workflows/test-server.yml"
       - "components/fires-server/**"
       - "pnpm-lock.json"
 
@@ -54,7 +55,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: fires_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U ${POSTGRES_USER}"
           --health-interval 10ms
           --health-timeout 3s
           --health-retries 50
@@ -70,11 +71,8 @@ jobs:
       PUBLIC_URL: https://fires.test/
       LOG_LEVEL: info
       APP_KEY: "test_determinist_key_DO_NOT_USE_IN_PRODUCTION"
-      DATABASE_HOST: 127.0.0.1
-      DATABASE_PORT: 54321
-      DATABASE_USER: postgres
-      DATABASE_PASSWORD: postgres
-      DATABASE_DATABASE: fires_test
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54321/fires_test
+      DATABASE_POOL_MAX: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/components/fires-server/.env.docker
+++ b/components/fires-server/.env.docker
@@ -1,3 +1,6 @@
+TZ=UTC
+NODE_ENV=production
+
 PORT=4444
 
 # Assuming the docker container is mapped to the same port on the host machine
@@ -8,8 +11,5 @@ LOG_LEVEL=trace
 # You can generate an APP_KEY with: `node ace generate:key` or `openssl rand -hex 32`
 APP_KEY=test_determinist_key_DO_NOT_USE_IN_PRODUCTION
 
-DATABASE_HOST=postgresql
-DATABASE_PORT=5432
-DATABASE_USER=postgres
-DATABASE_PASSWORD=postgres
-DATABASE_DATABASE=fires_production
+DATABASE_URL=postgresql://postgres:postgres@fires-postgresql:5432/fires_production
+DATABASE_POOL_MAX=10

--- a/components/fires-server/.env.example
+++ b/components/fires-server/.env.example
@@ -1,5 +1,5 @@
 TZ=UTC
-NODE_ENV=development
+NODE_ENV=production
 
 PORT=4444
 HOST=localhost
@@ -8,14 +8,12 @@ PUBLIC_URL=http://$HOST:$PORT/
 LOG_LEVEL=info
 
 # You can generate an APP_KEY with: node ace generate:key
-APP_KEY=
+# APP_KEY=
 
-DATABASE_HOST=127.0.0.1
-DATABASE_PORT=5432
-DATABASE_USER=fires
-DATABASE_PASSWORD=some-long-password
-# Optional: defaults to fires_<NODE_ENV>
-# DATABASE_DATABASE=fires_production
+# The database name in the connection string is optional, and defaults to
+# `fires_<NODE_ENV>` if not present.
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fires_production
+DATABASE_POOL_MAX=10
 
 # Optional, defaults to `en`
 # DEFAULT_LOCALE=en

--- a/components/fires-server/package.json
+++ b/components/fires-server/package.json
@@ -85,6 +85,7 @@
     "luxon": "^3.5.0",
     "markdown-it": "^14.1.0",
     "pg": "^8.13.3",
+    "pg-connection-string": "^2.8.5",
     "reflect-metadata": "^0.2.2",
     "uuid": "^11.1.0"
   },

--- a/components/fires-server/start/env.ts
+++ b/components/fires-server/start/env.ts
@@ -46,12 +46,8 @@ export default await Env.create(new URL('../', import.meta.url), {
   | Variables for configuring database connection
   |----------------------------------------------------------
   */
-  DATABASE_HOST: Env.schema.string({ format: 'host' }),
-  DATABASE_PORT: Env.schema.number(),
-  DATABASE_USER: Env.schema.string(),
-  DATABASE_PASSWORD: Env.schema.string.optional(),
-  DATABASE_NAME: Env.schema.string.optional(),
-  DATABASE_SSL_CA_CERT: Env.schema.string.optional(),
+  DATABASE_URL: Env.schema.string(),
+  DATABASE_POOL_MAX: Env.schema.number.optional(),
 
   /*
   |----------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       pg:
         specifier: ^8.13.3
         version: 8.15.6
+      pg-connection-string:
+        specifier: ^2.8.5
+        version: 2.8.5
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2


### PR DESCRIPTION
This change removes the previous `DATABASE_*` environment variables, and replaces them with a singular `DATABASE_URL`. This ensures we have better handling of SSL Certificates for self-signed certificates (e.g., when the postgresql database is on a managed service like DigitalOcean).

When using `DATABASE_URL` you can omit the database name (the path component of the connection string), in which case, we will automatically use the combined of `fires_` and the current `NODE_ENV` as the database name.

Also introduced is `DATABASE_POOL_MAX` to configure the database pool size, as we weren't previously using database connection pooling.
