### PR TITLE
Refactor: improve request tests

### DIFF
--- a/.changeset/plenty-rules-brush.md
+++ b/.changeset/plenty-rules-brush.md
@@ -1,0 +1,9 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Refactor: Improve request tests
+
+This switches us to use the japa plugin approach for request tests, injecting a `assertResponse` and `request` values into `TestContext`, which does the `createServer` / `createRequestInjection` logic automatically. In the future this plugin will be extracted into a stand-alone japa plugin for doing fast request testing.
+
+Also ensures the database is correctly setup before tests.

--- a/components/fires-server/tests/bootstrap.ts
+++ b/components/fires-server/tests/bootstrap.ts
@@ -1,9 +1,9 @@
 import { assert } from '@japa/assert'
-import { apiClient } from '@japa/api-client'
 import app from '@adonisjs/core/services/app'
 import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
+import { requestTests } from './plugins/request_tests.js'
 
 /**
  * This file is imported by the "bin/test.ts" entrypoint file
@@ -22,7 +22,7 @@ if (process.env.GITHUB_ACTIONS === 'true') {
  * Configure Japa plugins in the plugins array.
  * Learn more - https://japa.dev/docs/runner-config#plugins-optional
  */
-export const plugins: Config['plugins'] = [assert(), apiClient(), pluginAdonisJS(app)]
+export const plugins: Config['plugins'] = [assert(), requestTests(app), pluginAdonisJS(app)]
 
 /**
  * Configure lifecycle function to run before and after all the

--- a/components/fires-server/tests/bootstrap.ts
+++ b/components/fires-server/tests/bootstrap.ts
@@ -32,7 +32,7 @@ export const plugins: Config['plugins'] = [assert(), apiClient(), pluginAdonisJS
  * The teardown functions are executed after all the tests
  */
 export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
-  setup: [],
+  setup: [() => testUtils.db().migrate()],
   teardown: [],
 }
 

--- a/components/fires-server/tests/helpers/middleware_injection_test.ts
+++ b/components/fires-server/tests/helpers/middleware_injection_test.ts
@@ -3,7 +3,6 @@ import { HttpContext } from '@adonisjs/core/http'
 import { HttpContextFactory, RequestFactory, ResponseFactory } from '@adonisjs/core/factories/http'
 
 import inject from 'light-my-request'
-import testUtils from '@adonisjs/core/services/test_utils'
 
 export function createMiddlewareInjectionTest(callback: (ctx: HttpContext) => Promise<void>) {
   const server: RequestListener = async (req, res) => {
@@ -19,16 +18,5 @@ export function createMiddlewareInjectionTest(callback: (ctx: HttpContext) => Pr
     ctx.response.finish()
   }
 
-  return inject(server)
-}
-
-export async function createServer(): Promise<RequestListener> {
-  const server = await testUtils.app.container.make('server')
-  await server.boot()
-
-  return server.handle.bind(server)
-}
-
-export function createRequestInjection(server: RequestListener) {
   return inject(server)
 }

--- a/components/fires-server/tests/plugins/request_tests.ts
+++ b/components/fires-server/tests/plugins/request_tests.ts
@@ -1,0 +1,129 @@
+import type { PluginFn } from '@japa/runner/types'
+import type { Assert } from '@japa/assert'
+import { TestContext } from '@japa/runner/core'
+import { ApplicationService } from '@adonisjs/core/types'
+import inject from 'light-my-request'
+
+// These come from light-my-request:
+type HttpMethod = 'delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put' | 'trace'
+type RequestMethods = Record<HttpMethod, (url: string) => inject.Chain>
+
+type ExpectedChallenge = {
+  realm: string
+  scheme: string
+  params?: Record<string, string>
+}
+
+class ResponseAssertions {
+  private assert: Assert
+
+  constructor(_options: {}, assert: Assert) {
+    this.assert = assert
+  }
+
+  status(response: inject.Response, expectedStatus: number) {
+    this.assert.equal(response.statusCode, expectedStatus)
+  }
+
+  contentType(response: inject.Response, expectedContentType: string) {
+    this.assert.include(response.headers, { 'content-type': expectedContentType })
+  }
+
+  header(response: inject.Response, name: string, value?: string) {
+    const header = name.toLowerCase()
+    this.assert.property(response.headers, header)
+
+    if (value !== undefined) {
+      this.assert.include(response.headers, { [header]: value })
+    }
+  }
+
+  challenge(response: inject.Response, expectedChallenge: ExpectedChallenge) {
+    this.assert.equal(response.statusCode, 401)
+
+    const challenge =
+      (Array.isArray(response.headers['www-authenticate'])
+        ? response.headers['www-authenticate'][0]
+        : response.headers['www-authenticate']) ?? ''
+
+    this.assert.ok(
+      challenge.startsWith(`${expectedChallenge.scheme} `),
+      'Challenge contains correct auth scheme'
+    )
+
+    if (typeof expectedChallenge.params === 'object') {
+      const challengeParams = challenge
+        .slice(expectedChallenge.scheme.length + 1)
+        .split(/,\s+/)
+        .reduce<Record<string, string>>((acc, param) => {
+          const [name, value] = param.split('=', 2)
+          acc[name] = JSON.parse(value)
+
+          return acc
+        }, {})
+
+      this.assert.include(challengeParams, expectedChallenge.params)
+    }
+  }
+}
+
+/**
+ * API client plugin registers an HTTP request client that
+ * can be used for testing API endpoints.
+ */
+export function requestTests(app: ApplicationService): PluginFn {
+  return async function () {
+    const server = await app.container.make('server')
+    await server.boot()
+
+    const requestHandler = server.handle.bind(server)
+
+    TestContext.getter(
+      'request',
+      function (this: TestContext) {
+        return {
+          get(url: string) {
+            return inject(requestHandler).get(url)
+          },
+          post(url: string) {
+            return inject(requestHandler).post(url)
+          },
+          put(url: string) {
+            return inject(requestHandler).put(url)
+          },
+          patch(url: string) {
+            return inject(requestHandler).patch(url)
+          },
+          delete(url: string) {
+            return inject(requestHandler).delete(url)
+          },
+          trace(url: string) {
+            return inject(requestHandler).trace(url)
+          },
+          options(url: string) {
+            return inject(requestHandler).options(url)
+          },
+          head(url: string) {
+            return inject(requestHandler).head(url)
+          },
+        }
+      },
+      true
+    )
+
+    TestContext.getter(
+      'assertResponse',
+      function (this: TestContext) {
+        return new ResponseAssertions({}, this.assert)
+      },
+      true
+    )
+  }
+}
+
+declare module '@japa/runner/core' {
+  interface TestContext {
+    request: RequestMethods
+    assertResponse: ResponseAssertions
+  }
+}

--- a/components/fires-server/tests/request/controllers/labels.spec.ts
+++ b/components/fires-server/tests/request/controllers/labels.spec.ts
@@ -1,20 +1,16 @@
 import { test } from '@japa/runner'
 
-import { createRequestInjection, createServer } from '#tests/helpers/http_injection_test'
+import Label from '#models/label'
 import { LabelFactory } from '#database/factories/label_factory'
 import { CONTEXT } from '#serializers/labels_serializer'
-import Label from '#models/label'
 import { XSDDateFormat } from '#utils/jsonld'
 
 test.group('Controllers / labels / content negotiation', () => {
-  test('correctly negotiates to JSON', async ({ assert }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
+  test('correctly negotiates to JSON', async ({ assert, assertResponse, request }) => {
     const response = await request.get('/labels').headers({ accept: 'application/json' }).end()
 
-    assert.equal(response.statusCode, 200)
-    assert.equal(response.headers['content-type'], 'application/json; charset=utf-8')
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/json; charset=utf-8')
 
     const json = response.json()
 
@@ -27,38 +23,29 @@ test.group('Controllers / labels / content negotiation', () => {
     assert.equal(json['summary'], 'Labels from https://fires.test/')
   })
 
-  test('correctly negotiates with JSON-LD', async ({ assert }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
+  test('correctly negotiates with JSON-LD', async ({ assert, assertResponse, request }) => {
     const response = await request.get('/labels').headers({ accept: 'application/ld+json' }).end()
 
-    assert.equal(response.statusCode, 200)
-    assert.equal(response.headers['content-type'], 'application/ld+json; charset=utf-8')
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/ld+json; charset=utf-8')
 
     const json = response.json()
 
     assert.deepEqual(json['@context'], CONTEXT)
   })
 
-  test('correctly negotiates to HTML', async ({ assert }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
+  test('correctly negotiates to HTML', async ({ assertResponse, request }) => {
     const response = await request.get('/labels').headers({ accept: 'text/html' }).end()
 
-    assert.equal(response.statusCode, 200)
-    assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'text/html; charset=utf-8')
   })
 
-  test('defaults to HTML when no Accept header is present', async ({ assert }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
+  test('defaults to HTML when no Accept header is present', async ({ assertResponse, request }) => {
     const response = await request.get('/labels').end()
 
-    assert.equal(response.statusCode, 200)
-    assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'text/html; charset=utf-8')
   })
 })
 
@@ -67,15 +54,13 @@ test.group('Controllers / labels', (group) => {
     await Label.query().delete()
   })
 
-  test('fetching the collection of labels', async ({ assert }) => {
+  test('fetching the collection of labels', async ({ assert, assertResponse, request }) => {
     const label = await LabelFactory.create()
-
-    const server = await createServer()
-    const request = createRequestInjection(server)
 
     const response = await request.get(`/labels`).headers({ accept: 'application/json' }).end()
 
-    assert.equal(response.statusCode, 200)
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/json; charset=utf-8')
 
     const json = response.json()
 
@@ -90,18 +75,16 @@ test.group('Controllers / labels', (group) => {
     assert.notDeepInclude(json.items[0], ['owl:deprecated'])
   })
 
-  test('fetching an individual label', async ({ assert }) => {
+  test('fetching an individual label', async ({ assert, assertResponse, request }) => {
     const label = await LabelFactory.create()
-
-    const server = await createServer()
-    const request = createRequestInjection(server)
 
     const response = await request
       .get(`/labels/${label.id}`)
       .headers({ accept: 'application/json' })
       .end()
 
-    assert.equal(response.statusCode, 200)
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/json; charset=utf-8')
 
     const json = response.json()
 
@@ -111,18 +94,20 @@ test.group('Controllers / labels', (group) => {
     assert.equal(json.summary, label.summary)
   })
 
-  test('when a label is deprecated, it returns owl:deprecated true', async ({ assert }) => {
+  test('when a label is deprecated, it returns owl:deprecated true', async ({
+    assert,
+    assertResponse,
+    request,
+  }) => {
     const label = await LabelFactory.apply('deprecated').create()
-
-    const server = await createServer()
-    const request = createRequestInjection(server)
 
     const response = await request
       .get(`/labels/${label.id}`)
       .headers({ accept: 'application/json' })
       .end()
 
-    assert.equal(response.statusCode, 200)
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/json; charset=utf-8')
 
     const json = response.json()
 

--- a/components/fires-server/tests/request/controllers/well_known/nodeinfo.spec.ts
+++ b/components/fires-server/tests/request/controllers/well_known/nodeinfo.spec.ts
@@ -1,19 +1,16 @@
 import { test } from '@japa/runner'
-
-import { createRequestInjection, createServer } from '#tests/helpers/http_injection_test'
 import { NodeInfo, NodeInfoDiscovery } from '#controllers/well-known/nodeinfo_controller'
 
 test.group('Controllers / nodeinfo', () => {
   test('GET /.well-known/nodeinfo returns JSON document pointing to nodeinfo', async ({
     assert,
+    assertResponse,
+    request,
   }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
     const response = await request.get('/.well-known/nodeinfo').end()
 
-    assert.equal(response.statusCode, 200)
-    assert.include(response.headers, { 'content-type': 'application/json; charset=utf-8' })
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/json; charset=utf-8')
 
     const json = response.json<NodeInfoDiscovery>()
 
@@ -27,17 +24,18 @@ test.group('Controllers / nodeinfo', () => {
     ])
   })
 
-  test('GET /nodeinfo/2.1 endpoint returns JSON with nodeinfo properties', async ({ assert }) => {
-    const server = await createServer()
-    const request = createRequestInjection(server)
-
+  test('GET /nodeinfo/2.1 endpoint returns JSON with nodeinfo properties', async ({
+    assert,
+    assertResponse,
+    request,
+  }) => {
     const response = await request.get('/nodeinfo/2.1').end()
 
-    assert.equal(response.statusCode, 200)
-    assert.include(response.headers, {
-      'content-type':
-        'application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"',
-    })
+    assertResponse.status(response, 200)
+    assertResponse.contentType(
+      response,
+      'application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"'
+    )
 
     const json = response.json<NodeInfo>()
 

--- a/components/fires-server/tests/request/middleware/disable_multipart_requests_middleware.spec.ts
+++ b/components/fires-server/tests/request/middleware/disable_multipart_requests_middleware.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@japa/runner'
-import { createMiddlewareInjectionTest } from '#tests/helpers/http_injection_test'
+import { createMiddlewareInjectionTest } from '#tests/helpers/middleware_injection_test'
 
 import DisableMultipartRequestsMiddleware from '#middleware/disable_multipart_requests_middleware'
 


### PR DESCRIPTION
This switches us to use the japa plugin approach for request tests, injecting a `assertResponse` and `request` values into TestContext, which does the `createServer` / `createRequestInjection` logic automatically. In the future this plugin will be extracted into a stand-alone japa plugin for doing fast request testing.

I'm still needing to add a few more assertions to `assertResponse` before moving towards a plugin.