### PR TITLE
Fix primary key assignment in models

### DIFF
--- a/components/fires-server/app/models/label.ts
+++ b/components/fires-server/app/models/label.ts
@@ -3,6 +3,8 @@ import { BaseModel, beforeCreate, column } from '@adonisjs/lucid/orm'
 import { v7 as uuidv7 } from 'uuid'
 
 export default class Label extends BaseModel {
+  selfAssignPrimaryKey = true
+
   @column({ isPrimary: true })
   declare id: string
 


### PR DESCRIPTION
This is necessary when doing `beforeCreate` to assign a primary key, as we do with uuid v7 primary keys, otherwise the the ID of the model may be needing a full fetch of the model from the database.