### PR TITLE
Add CLI commands for Access Tokens

### DIFF
--- a/.changeset/sweet-pears-tell.md
+++ b/.changeset/sweet-pears-tell.md
@@ -1,0 +1,13 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Add CLI commands for Access Tokens
+
+This change introduces the following `node ace` commands to manage access tokens on the FIRES reference server:
+
+- `fires:tokens:list`
+- `fires:tokens:create`
+- `fires:tokens:delete <token_prefix>`
+
+Also updates the documentation and seeders to fix a few small issues.

--- a/components/fires-server/README.md
+++ b/components/fires-server/README.md
@@ -2,12 +2,21 @@
 
 [![AGPL License](https://img.shields.io/badge/license-AGPL-blue.svg)](http://www.gnu.org/licenses/agpl-3.0)
 
+## Features
+
+- [x] /.well-known/nodeinfo endpoints
+- [x] Labels Endpoint
+- [x] non-standard API for managing Labels (still need to figure out a standardisable API here)
+- [x] Basic Web UI for reading data
+- [x] Authentication & Authorization
+- [ ] Datasets
+
 ## Running in Docker
 
 If you just want to try out the FIRES server via docker compose, you can use:
 
 ```sh
-$ docker compose up
+$ docker compose up -d
 ```
 
 This will spin up postgresql and the fires-server, after which you'll need to run the migrations and seed the data:
@@ -31,10 +40,10 @@ $ docker compose down
 If you already have postgresql running in docker and want to use that instead, you can with the following, but you'll need to know the network name that postgresql is on, which you can find out with:
 
 ```sh
-$ docker inspect --format='{{println .HostConfig.NetworkMode}}' postgresql
+$ docker inspect --format='{{println .HostConfig.NetworkMode}}' fires-postgresql
 ```
 
-Where `postgesql` is the name of the postgesql container you have running.
+Where `fires-postgesql` is the name of the postgesql container you have running.
 
 You'll also need to create the database in postgresql for the fires server to use.
 
@@ -46,21 +55,54 @@ $ cp .env.docker .env.local
 # Run the migrations:
 $ docker run --net <network_name> --env-file=.env.local ghcr.io/fedimod/fires-server:edge node ace migration:fresh --force
 
-# Seed the database with example data:
+# Run the setup:
+$ docker run --net <network_name> --env-file=.env.local ghcr.io/fedimod/fires-server:edge node ace fires:setup
+
+# Seed the database with example data (optional):
 $ docker run --net <network_name> --env-file=.env.local ghcr.io/fedimod/fires-server:edge node ace db:seed
 
 # Run the server:
 $ docker run --net <network_name> --env-file=.env.local -p 4444:4444 ghcr.io/fedimod/fires-server:edge
 ```
 
-## Features
+#### Managing Access Tokens
 
-- [x] /.well-known/nodeinfo endpoints
-- [x] Labels Endpoint
-- [x] non-standard API for managing Labels (still need to figure out a standardisable API here)
-- [x] Basic Web UI for reading data
-- [ ] Authentication & Authorization
-- [ ] Datasets
+The following commands exist for managing access tokens (necessary to access the non-standard API for working with Labels and Datasets):
+
+- `fires:tokens:list`
+- `fires:tokens:create`
+- `fires:tokens:delete <token_prefix>`
+
+In docker, you need to run these from a command line, so first get the Container ID using:
+
+```sh
+$ docker ps -f "name=fires-server" --format "{{.ID}}"
+```
+
+Then start a command line using:
+
+```sh
+$ docker exec -it <Container ID> /bin/sh
+```
+
+Then you can run the following commands which are interactive:
+
+```sh
+# Create an access token:
+# Note: the full access token will only be printed once.
+$ node ace fires:tokens:create
+
+# List access tokens:
+$ node ace fires:tokens:list
+
+# Delete an access token
+# - <token_prefix> is the value to match on, for example: fires_1SE0R62F10juqJaTBwzMmwaNbxtBOQh8
+$ node ace fires:tokens:delete <token_prefix>
+```
+
+When you're done, you can enter `exit` to exit the command prompt.
+
+Unfortunately at this time it is not possible to run these commands via `docker run` due to a bug that causes the command to not correctly accept input.
 
 ### FIRES Protocol Endpoints
 
@@ -108,14 +150,18 @@ The FIRES reference server has a non-standard API for managing data stored on it
 
 #### Labels
 
+Authorization is provided via `Bearer` token, where the `<token>` below is the Access Token starting with `fires_`. For the `GET` request (first below), you need an access token with the `read` ability. For all other requests, you need the `admin` ability.
+
 ```http
 GET /api/labels
+Authorization: Bearer <token>
 ```
 
 Returns the raw list of labels on the server.
 
 ```http
 POST /api/labels
+Authorization: Bearer <token>
 
 {"name": "test label"}
 ```
@@ -124,6 +170,7 @@ Creates a new label on the FIRES server called "test label"
 
 ```http
 PATCH /api/labels/:id
+Authorization: Bearer <token>
 
 {"summary": "test label for demonstration purposes"}
 ```
@@ -132,6 +179,7 @@ Partially updates the label identified by `:id`
 
 ```http
 PUT /api/labels/:id
+Authorization: Bearer <token>
 
 {"name": "Edited label", "summary": "test label for demonstration purposes"}
 ```
@@ -140,12 +188,14 @@ Overwrites the label identified by `:id`
 
 ```http
 DELETE /api/labels/:id
+Authorization: Bearer <token>
 ```
 
 Deprecates the label identified by `:id`
 
 ```http
 DELETE /api/labels/:id?force=true
+Authorization: Bearer <token>
 ```
 
 Completely deletes the label identified by `:id`, usage of this isn't recommended in production servers, as the label may be present in an existing dataset.

--- a/components/fires-server/commands/fires_tokens_create.ts
+++ b/components/fires-server/commands/fires_tokens_create.ts
@@ -1,0 +1,60 @@
+import AccessTokenService from '#services/access_token_service'
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+
+export default class FiresTokensCreate extends BaseCommand {
+  static commandName = 'fires:tokens:create'
+  static description = 'Create an access token'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    const description = await this.prompt.ask('Name or description for the Access Token', {
+      validate(value) {
+        return value.length > 0
+      },
+    })
+
+    const abilities = await this.prompt.multiple(
+      'Select abilities',
+      [
+        {
+          name: 'read',
+          message: 'Read data',
+        },
+        {
+          name: 'write',
+          message: 'Write data',
+        },
+        {
+          name: 'admin',
+          message: 'Administrate the server (including labels)',
+        },
+      ],
+      {
+        validate(values) {
+          return values.length > 0 ? true : 'Please select at least one option'
+        },
+      }
+    )
+
+    const createToken = this.logger.action('Creating Access Token')
+    try {
+      const token = await AccessTokenService.create(abilities, description)
+      createToken.displayDuration().succeeded()
+
+      const sticker = this.ui.sticker()
+      sticker
+        .add('Access Token created successfully!')
+        .add('')
+        .add(`${this.colors.cyan(token.token.release())}`)
+        .add('')
+        .add(`${this.colors.yellow('Note: This token will not be shown again.')}`)
+        .render()
+    } catch (error) {
+      createToken.failed(error)
+    }
+  }
+}

--- a/components/fires-server/commands/fires_tokens_delete.ts
+++ b/components/fires-server/commands/fires_tokens_delete.ts
@@ -1,0 +1,62 @@
+import AccessToken from '#models/access_token'
+import { args, BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import { errors } from '@adonisjs/lucid'
+import { DateTime } from 'luxon'
+
+export default class FiresTokensDelete extends BaseCommand {
+  static commandName = 'fires:tokens:delete'
+  static description = 'Delete an access token'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  @args.string()
+  declare token: string
+
+  async run() {
+    const table = this.ui
+      .table()
+      .head(['Token (truncated)', 'Description', 'Abilities', 'Last Used At'])
+
+    let token: AccessToken | null = null
+
+    try {
+      token = await AccessToken.query().whereLike('token', `${this.token}%`).firstOrFail()
+    } catch (error) {
+      if (error instanceof errors.E_ROW_NOT_FOUND) {
+        this.logger.error(`Could not find access token: ${this.token}`)
+        this.exitCode = 1
+        return this.terminate()
+      }
+
+      throw error
+    }
+
+    table
+      .row([
+        token.token.release().split('.')[0],
+        token.description,
+        token.abilities.join(' '),
+        token.lastUsedAt?.toLocaleString(DateTime.DATETIME_SHORT) ?? '-',
+      ])
+      .render()
+
+    const deleteToken = await this.prompt.confirm('Is this the token you wish to delete?')
+
+    if (!deleteToken) {
+      this.logger.success('Okay, nothing to do.')
+      return this.terminate()
+    }
+
+    const deleteTokenAction = this.logger.action('Deleting Access Token')
+    try {
+      await token.delete()
+      deleteTokenAction.displayDuration().succeeded()
+    } catch (error) {
+      deleteTokenAction.failed(error)
+      this.exitCode = 1
+    }
+  }
+}

--- a/components/fires-server/commands/fires_tokens_list.ts
+++ b/components/fires-server/commands/fires_tokens_list.ts
@@ -1,0 +1,31 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import AccessToken from '#models/access_token'
+import { DateTime } from 'luxon'
+
+export default class FiresTokensList extends BaseCommand {
+  static commandName = 'fires:tokens:list'
+  static description = 'Lists access tokens'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    const table = this.ui
+      .table()
+      .head(['Token (truncated)', 'Description', 'Abilities', 'Last Used At'])
+    const tokens = await AccessToken.all()
+
+    tokens.forEach((token) => {
+      table.row([
+        token.token.release().split('.')[0],
+        token.description,
+        token.abilities.join(' '),
+        token.lastUsedAt?.toLocaleString(DateTime.DATETIME_SHORT) ?? '-',
+      ])
+    })
+
+    table.render()
+  }
+}

--- a/components/fires-server/commands/fires_tokens_list.ts
+++ b/components/fires-server/commands/fires_tokens_list.ts
@@ -17,6 +17,10 @@ export default class FiresTokensList extends BaseCommand {
       .head(['Token (truncated)', 'Description', 'Abilities', 'Last Used At'])
     const tokens = await AccessToken.all()
 
+    if (tokens.length === 0) {
+      table.row([{ colSpan: 4, content: 'No Access Tokens Exist' }])
+    }
+
     tokens.forEach((token) => {
       table.row([
         token.token.release().split('.')[0],

--- a/components/fires-server/database/seeders/example_data_seeder.ts
+++ b/components/fires-server/database/seeders/example_data_seeder.ts
@@ -1,9 +1,22 @@
 import Label from '#models/label'
+import Setting from '#models/setting'
 import { BaseSeeder } from '@adonisjs/lucid/seeders'
 import dedent from 'dedent'
 
 export default class extends BaseSeeder {
   async run() {
+    await Setting.updateOrCreateMany('key', [
+      {
+        key: 'name',
+        value: 'Example FIRES Server',
+      },
+      {
+        key: 'summary',
+        value:
+          'An example FIRES server for labels, moderation advisories, and moderation recommendations.',
+      },
+    ])
+
     await Label.updateOrCreateMany('name', [
       {
         name: 'CSAM',

--- a/components/fires-server/docker-compose.yml
+++ b/components/fires-server/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
-    # build: .
+    build: ../../
     image: ghcr.io/fedimod/fires-server:edge
     restart: always
     env_file: .env.docker


### PR DESCRIPTION
This adds some CLI commands for creating, deleting and listing access tokens. For now I've opted to not give these commands test coverage, as they're still subject to changes.