### PR TITLE
Attempt to fix changesets configuration for releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "tag": true,
+    "version": true
+  }
 }


### PR DESCRIPTION
For some reason merging #38 didn't actually create the tag for the release. I'm not sure why.