### PR TITLE
Fix docker image publishing when releases are created

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -1,8 +1,7 @@
 name: Build release container images
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -10,6 +9,7 @@ permissions:
 
 jobs:
   build-image:
+    if: ${{ startsWith(github.ref, 'refs/tags/@fedimod/fires-server') }}
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile


### PR DESCRIPTION
Due to the way the release is created, the `tags` seemingly aren't pushed, which is odd, but okay. This switches to using the published event on releases.