### PR TITLE
Fix container image releases

### DIFF
--- a/.changeset/evil-breads-tap.md
+++ b/.changeset/evil-breads-tap.md
@@ -1,0 +1,7 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Release docker images correctly
+
+Previously the docker images for the release were meant to happen on push of tags, but for some reason the tags pushed by the `release.yml` workflow didn't trigger the action to run. I suspect that's because the tags were created via the API instead of via a `git push`. Have switched to using the release published event instead.


### PR DESCRIPTION
This means we won't have a container image for v0.1.0, unfortunately, but we should for v0.1.1

CI/CD pipelines are always a source of much joy and fun.