### PR TITLE
Fix release workflow breaking due to missing single quotes

### DIFF
--- a/.changeset/every-spoons-create.md
+++ b/.changeset/every-spoons-create.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix missing quotes on json when doing releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         id: release
         run: |
           echo '::debug::${{steps.changesets.outputs.publishedPackages}}'
-          tags=$(jq -cr 'map([.name, .version] | join("@")) | map("refs/tags/" + .)' <<< ${{ steps.changesets.outputs.publishedPackages }})
+          tags=$(jq -cr 'map([.name, .version] | join("@")) | map("refs/tags/" + .)' <<< '${{ steps.changesets.outputs.publishedPackages }}')
           echo "tags='${tags%,}'" >> "$GITHUB_OUTPUT"
 
   release-fires-server-image:


### PR DESCRIPTION
There has gotta be a better way to do this.