### PR TITLE
Fix release workflow breaking due missing tags

### DIFF
--- a/.changeset/three-plums-switch.md
+++ b/.changeset/three-plums-switch.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix release not working"

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -84,6 +84,7 @@ jobs:
           images: ${{ inputs.push_to_images }}
           flavor: ${{ inputs.flavor }}
           labels: ${{ inputs.labels }}
+          tags: ""
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
-      tags: ${{ steps.release.outputs.tags }}
+      matrix: ${{ steps.release.outputs.matrix }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -43,8 +43,8 @@ jobs:
         uses: changesets/action@v1
 
         with:
-          title: Prepare release
-          commit: prepare release of packages
+          title: Prepare releases
+          commit: prepare releases
           version: pnpm ci:version
           publish: pnpm ci:release
           createGithubReleases: true
@@ -55,23 +55,23 @@ jobs:
       - name: Setup release variables
         id: release
         run: |
-          echo '::debug::${{steps.changesets.outputs.publishedPackages}}'
-          tags=$(jq -cr 'map([.name, .version] | join("@")) | map("refs/tags/" + .)' <<< '${{ steps.changesets.outputs.publishedPackages }}')
-          echo "tags=${tags%,}" >> "$GITHUB_OUTPUT"
+          echo '${{steps.changesets.outputs.publishedPackages}}'
+          packages=$(jq -cr '[.[] | select( [ .name | contains("fires-server") ] | any)]' <<< '${{ steps.changesets.outputs.publishedPackages }}')
+          release_matrix=$(jq -cr '{ include: . | map({ tag: ("refs/tags/" + .name + "@" + .version), version: .version, package: (.name | ltrimstr("@fedimod/")) }) }' <<< $packages)
+          echo "matrix=${release_matrix%,}" >> "$GITHUB_OUTPUT"
 
   release-fires-server-image:
     needs: [release]
-    if: ${{ needs.release.outputs.published == 'true' }}
     strategy:
-      matrix:
-        git_ref: ${{ fromJson(needs.release.outputs.tags) }}
+      matrix: ${{ fromJson(needs.release.outputs.matrix) }}
+    if: ${{ needs.release.outputs.published == 'true' }}
     uses: ./.github/workflows/build-container-image.yml
     with:
-      git_ref: ${{ matrix.git_ref }}
+      git_ref: ${{ matrix.tag }}
       file_to_build: Dockerfile
-      target_stage: fires-server
+      target_stage: ${{ matrix.package }}
       push_to_images: |
-        ghcr.io/fedimod/fires-server
+        ghcr.io/fedimod/${{ matrix.package }}
       # Do not use cache when building releases, so apk update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch
@@ -79,6 +79,6 @@ jobs:
       flavor: |
         latest=true
       tags: |
-        type=pep440,pattern={{raw}}
-        type=pep440,pattern=v{{major}}.{{minor}}
+        type=semver,pattern={{version}},value=${{matrix.version}}
+        type=semver,pattern={{major}}.{{minor}},value=${{matrix.version}}
     secrets: inherit


### PR DESCRIPTION
This changes the entire thing to construct the matrix via `jq` and then explicitly pass in the value for the tags.