### PR TITLE
Add guard for empty matrix in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     needs: [release]
     strategy:
       matrix: ${{ fromJson(needs.release.outputs.matrix) }}
-    if: ${{ needs.release.outputs.published == 'true' }}
+    if: ${{ needs.release.outputs.published == 'true' && needs.release.outputs.matrix != '{"include":[]}' }}
     uses: ./.github/workflows/build-container-image.yml
     with:
       git_ref: ${{ matrix.tag }}


### PR DESCRIPTION
If the matrix is empty, due to the `fires-server` package not being released, then we don't need to do anything.

I'm not sure what exactly an empty matrix would do, but I can test next time I version just the documentation.