### PR TITLE
Ensure settings for view middleware are accessed in correct order

### DIFF
--- a/.changeset/stupid-drinks-reply.md
+++ b/.changeset/stupid-drinks-reply.md
@@ -1,0 +1,7 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix bug with Server details being incorrectly displayed
+
+In some situations, the two settings for the server name and summary were being displayed in the wrong position, e.g., name would appear as summary and summary as name. This turned out to be a bug in how we were fetching the settings back in the middleware that supplies this information to the views.

--- a/components/fires-server/app/middleware/view_data_middleware.ts
+++ b/components/fires-server/app/middleware/view_data_middleware.ts
@@ -16,7 +16,9 @@ export default class ViewDataMiddleware {
     }
 
     if (!ctx.request.header('Accept') || ctx.request.accepts(['html', '*/*']) === 'html') {
-      const [name, summary] = await Setting.findMany(['name', 'summary'])
+      const settings = await Setting.findMany(['name', 'summary'])
+      const name = settings.find((setting) => setting.key === 'name')
+      const summary = settings.find((setting) => setting.key === 'summary')
 
       ctx.view.share({
         provider: {


### PR DESCRIPTION
Turns out `Model.findMany` in lucid doesn't return the records in a deterministic order. This also resulted in a documentation change to Lucid from Adonis.js: https://github.com/adonisjs/lucid.adonisjs.com/pull/42/