### PR TITLE
Fix migrations running for CLI commands

### DIFF
--- a/.changeset/some-beds-type.md
+++ b/.changeset/some-beds-type.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix issue with migrations continuously running for CLI commands

--- a/components/fires-server/start/migrations.ts
+++ b/components/fires-server/start/migrations.ts
@@ -5,32 +5,34 @@ import logger from '@adonisjs/core/services/logger'
 import { MigrationRunner } from '@adonisjs/lucid/migration'
 import env from '#start/env'
 
-logger.info(
-  { shouldAutoMigrate: env.get('DATABASE_AUTOMIGRATE', false) },
-  'Checking for auto-migration'
-)
+if (app.getEnvironment() === 'web') {
+  logger.info(
+    { shouldAutoMigrate: env.get('DATABASE_AUTOMIGRATE', false) },
+    'Checking for auto-migration'
+  )
 
-if (env.get('DATABASE_AUTOMIGRATE', false) === true) {
-  const migrator = new MigrationRunner(db, app, {
-    direction: 'up',
-    dryRun: false,
-  })
+  if (env.get('DATABASE_AUTOMIGRATE', false) === true) {
+    const migrator = new MigrationRunner(db, app, {
+      direction: 'up',
+      dryRun: false,
+    })
 
-  migrator.on('start', () => {
-    logger.info('Running database migrations')
-  })
+    migrator.on('start', () => {
+      logger.info('Running database migrations')
+    })
 
-  migrator.on('migration:completed', (migration) => {
-    logger.info(`Migration ${migration.status}: ${migration.file.name}`)
-  })
+    migrator.on('migration:completed', (migration) => {
+      logger.info(`Migration ${migration.status}: ${migration.file.name}`)
+    })
 
-  migrator.on('migration:error', (migration) => {
-    logger.error(`Migration ${migration.status}: ${migration.file.name}`)
-  })
+    migrator.on('migration:error', (migration) => {
+      logger.error(`Migration ${migration.status}: ${migration.file.name}`)
+    })
 
-  migrator.on('end', () => {
-    logger.info('Migrations finished')
-  })
+    migrator.on('end', () => {
+      logger.info('Migrations finished')
+    })
 
-  await migrator.run()
+    await migrator.run()
+  }
 }


### PR DESCRIPTION
We only need the migrations to automatically run when the app is running the `web` command (which is the server). The commands don't need to check.