### PR TITLE
Add error handling to render views for 404 and 5xx

### DIFF
--- a/.changeset/nasty-breads-unite.md
+++ b/.changeset/nasty-breads-unite.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Add correct error pages for 404 and 5xx errors

--- a/components/fires-server/app/exceptions/handler.ts
+++ b/components/fires-server/app/exceptions/handler.ts
@@ -1,7 +1,14 @@
 import app from '@adonisjs/core/services/app'
 import { HttpContext, ExceptionHandler } from '@adonisjs/core/http'
+import { StatusPageRange, StatusPageRenderer } from '@adonisjs/core/types/http'
 
 export default class HttpExceptionHandler extends ExceptionHandler {
+  protected renderStatusPages = app.inProduction
+  protected statusPages: Record<StatusPageRange, StatusPageRenderer> = {
+    '404': (_, { view }) => view.render('errors/not-found'),
+    '500..599': (_, { view }) => view.render('errors/server-error'),
+  }
+
   /**
    * In debug mode, the exception handler will display verbose errors
    * with pretty printed stack traces.

--- a/components/fires-server/resources/styles/app.scss
+++ b/components/fires-server/resources/styles/app.scss
@@ -32,6 +32,11 @@
   }
 }
 
+.error-container {
+  text-align: center;
+  margin-top: 6rem;
+}
+
 header {
   border-bottom: 1px solid var(--pico-color-zinc-150);
   margin-bottom: 3rem;

--- a/components/fires-server/resources/views/components/layouts/error.edge
+++ b/components/fires-server/resources/views/components/layouts/error.edge
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="{{ i18n.locale }}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Error: {{ title }} | FIRES Server
+    </title>
+    @vite(['resources/styles/app.scss'])
+  </head>
+  <body>
+    <div class="root-container error-container">
+      <main>
+        <h2>
+          Error: {{ title }}
+        </h2>
+        {{{ await $slots.main() }}}
+      </main>
+    </div>
+  </body>
+</html>

--- a/components/fires-server/resources/views/errors/not-found.edge
+++ b/components/fires-server/resources/views/errors/not-found.edge
@@ -1,0 +1,7 @@
+@layouts.error({title: 'Not Found'})
+  @slot('main')
+    <p>
+      We couldn't find the page you are looking for.
+    </p>
+  @endslot
+@end

--- a/components/fires-server/resources/views/errors/server-error.edge
+++ b/components/fires-server/resources/views/errors/server-error.edge
@@ -1,0 +1,7 @@
+@layouts.error({title: 'Internal Server Error'})
+  @slot('main')
+    <p>
+      Something went wrong when we were trying to process your request.
+    </p>
+  @endslot
+@end


### PR DESCRIPTION
This adds views for 404 and 5xx errors that may be encountered whilst using FIRES.