### PR TITLE
Add note about changing label names

### DIFF
--- a/.changeset/hot-months-brush.md
+++ b/.changeset/hot-months-brush.md
@@ -2,6 +2,8 @@
 "@fedimod/fires-server": minor
 ---
 
-Add human-friendly "slugs" to Labels
+Add human-friendly URLs to Labels
 
 This changeset provides prettier URLs for human visitors, whilst still using the unchanging UUID identifier for use in datasets and machine-readable contexts. Additionally, it adds interlinking between the admin panel and the logged out homepage, and introduces copyable input boxes for the URL/IRIs of labels.
+
+Note: Changing a labels `name` will result in the URL changing for that label, and currently we don't preserve the previous URL and perform redirects, so this will break visitors.

--- a/components/fires-server/resources/views/admin/labels/_form.edge
+++ b/components/fires-server/resources/views/admin/labels/_form.edge
@@ -15,6 +15,7 @@
   })
 
   <label for="name">Name</label>
+  <small class="form-hint">Note: changing the name will result in the URL of the label changing, which may break links to this label from consumers.</small>
   <input
     type="text"
     required


### PR DESCRIPTION
If you change the name of the label, it will change the URL of the label, which could break consumers links to that label.