### PR TITLE
Split up routes file

### DIFF
--- a/components/fires-server/app/controllers/labels_controller.ts
+++ b/components/fires-server/app/controllers/labels_controller.ts
@@ -10,8 +10,6 @@ export default class LabelsController {
   async index({ response, view }: HttpContext) {
     const labels = await Label.query().preload('translations')
 
-    console.log({ labels })
-
     return response.negotiate(
       {
         json: async (acceptedType) => {

--- a/components/fires-server/app/exceptions/handler.ts
+++ b/components/fires-server/app/exceptions/handler.ts
@@ -30,7 +30,9 @@ export default class HttpExceptionHandler extends ExceptionHandler {
    * @note You should not attempt to send a response from this method.
    */
   async report(error: unknown, ctx: HttpContext) {
-    ctx.logger.error(error)
+    if (app.inDev) {
+      ctx.logger.error(error)
+    }
     return super.report(error, ctx)
   }
 }

--- a/components/fires-server/start/routes.ts
+++ b/components/fires-server/start/routes.ts
@@ -1,78 +1,12 @@
-/*
-|--------------------------------------------------------------------------
-| Routes file
-|--------------------------------------------------------------------------
-|
-| The routes file is used for defining the HTTP routes.
-|
-*/
-
 import router from '@adonisjs/core/services/router'
-import { middleware } from '#start/kernel'
 
-const AboutController = () => import('#controllers/about_controller')
-const NodeinfoController = () => import('#controllers/well-known/nodeinfo_controller')
-const LabelsController = () => import('#controllers/labels_controller')
-const LabelsApiController = () => import('#controllers/api/labels_controller')
-
-const AdminSessionsController = () => import('#controllers/admin/sessions_controller')
-const AdminOverviewController = () => import('#controllers/admin/overview_controller')
-const AdminLabelsController = () => import('#controllers/admin/labels_controller')
-const AdminSettingsController = () => import('#controllers/admin/settings_controller')
-
-router.get('/', [AboutController, 'index']).as('about')
 router.get('/health', ({ response }) => {
   return response.safeStatus(200).json({ ok: true })
 })
 
-// NodeInfo
-router.get('/.well-known/nodeinfo', [NodeinfoController, 'discovery']).as('nodeinfo.discovery')
-router.get('/nodeinfo/2.1', [NodeinfoController, 'retrieval']).as('nodeinfo.retrieval')
-
-// FIRES labels Endpoint
-router
-  .get('labels/:id', [LabelsController, 'show'])
-  .where('id', router.matchers.uuid())
-  .as('protocol.labels.show')
-
-router
-  .get('labels/:slug', [LabelsController, 'show'])
-  .where('slug', router.matchers.slug())
-  .as('labels.show')
-
-router.get('labels', [LabelsController, 'index']).as('labels.index')
-
-// Reference Server Management API:
-router
-  .group(() => {
-    router.resource('labels', LabelsApiController).except(['create', 'edit']).as('labels')
-  })
-  .use([middleware.tokenAuth(), middleware.requireTokenAuth()])
-  .prefix('api')
-  .as('api')
-
-// Admin panel:
-router.get('/admin', ({ response }) => response.redirect().toRoute('admin.overview'))
-router
-  .group(() => {
-    router.post('logout', [AdminSessionsController, 'logout']).as('logout')
-    router.get('overview', [AdminOverviewController, 'index']).as('overview')
-    router
-      .resource('labels', AdminLabelsController)
-      .as('labels')
-      .where('id', router.matchers.uuid())
-
-    router.get('settings', [AdminSettingsController, 'show']).as('settings')
-    router.post('settings', [AdminSettingsController, 'update']).as('settings.update')
-  })
-  .use(middleware.adminAuth())
-  .prefix('admin')
-  .as('admin')
-
-router.post('/admin/login', [AdminSessionsController, 'performLogin']).as('admin.performLogin')
-
-router
-  .group(() => {
-    router.get('/admin/login', [AdminSessionsController, 'login']).as('admin.login')
-  })
-  .use(middleware.guest())
+// Protocol must be first as Web routes use :slug for the label path component,
+// instead of :id, and the UUID matcher is more specific than the slug matcher.
+import '#start/routes/protocol'
+import '#start/routes/web'
+import '#start/routes/api'
+import '#start/routes/admin'

--- a/components/fires-server/start/routes/admin.ts
+++ b/components/fires-server/start/routes/admin.ts
@@ -1,0 +1,32 @@
+import { middleware } from '#start/kernel'
+import router from '@adonisjs/core/services/router'
+
+const AdminSessionsController = () => import('#controllers/admin/sessions_controller')
+const AdminOverviewController = () => import('#controllers/admin/overview_controller')
+const AdminLabelsController = () => import('#controllers/admin/labels_controller')
+const AdminSettingsController = () => import('#controllers/admin/settings_controller')
+
+router.get('/admin', ({ response }) => response.redirect().toRoute('admin.overview'))
+router
+  .group(() => {
+    router.post('logout', [AdminSessionsController, 'logout']).as('logout')
+    router.get('overview', [AdminOverviewController, 'index']).as('overview')
+    router
+      .resource('labels', AdminLabelsController)
+      .where('id', router.matchers.uuid())
+      .except(['destroy'])
+      .as('labels')
+
+    router.get('settings', [AdminSettingsController, 'show']).as('settings')
+    router.post('settings', [AdminSettingsController, 'update']).as('settings.update')
+  })
+  .use(middleware.adminAuth())
+  .prefix('admin')
+  .as('admin')
+
+router
+  .group(() => {
+    router.get('/admin/login', [AdminSessionsController, 'login']).as('admin.login')
+    router.post('/admin/login', [AdminSessionsController, 'performLogin']).as('admin.performLogin')
+  })
+  .use(middleware.guest())

--- a/components/fires-server/start/routes/api.ts
+++ b/components/fires-server/start/routes/api.ts
@@ -1,0 +1,16 @@
+import { middleware } from '#start/kernel'
+import router from '@adonisjs/core/services/router'
+
+const LabelsApiController = () => import('#controllers/api/labels_controller')
+
+router
+  .group(() => {
+    router
+      .resource('labels', LabelsApiController)
+      .except(['create', 'edit'])
+      .where('id', router.matchers.uuid())
+      .as('labels')
+  })
+  .use([middleware.tokenAuth(), middleware.requireTokenAuth()])
+  .prefix('api')
+  .as('api')

--- a/components/fires-server/start/routes/protocol.ts
+++ b/components/fires-server/start/routes/protocol.ts
@@ -1,0 +1,14 @@
+import router from '@adonisjs/core/services/router'
+
+const NodeinfoController = () => import('#controllers/well-known/nodeinfo_controller')
+const LabelsController = () => import('#controllers/labels_controller')
+
+// NodeInfo
+router.get('/.well-known/nodeinfo', [NodeinfoController, 'discovery']).as('nodeinfo.discovery')
+router.get('/nodeinfo/2.1', [NodeinfoController, 'retrieval']).as('nodeinfo.retrieval')
+
+// GET /labels in the protocol is handled by the web routes via content-negotiation
+router
+  .get('/labels/:id', [LabelsController, 'show'])
+  .where('id', router.matchers.uuid())
+  .as('protocol.labels.show')

--- a/components/fires-server/start/routes/web.ts
+++ b/components/fires-server/start/routes/web.ts
@@ -1,0 +1,12 @@
+import router from '@adonisjs/core/services/router'
+
+const AboutController = () => import('#controllers/about_controller')
+const LabelsController = () => import('#controllers/labels_controller')
+
+router.get('/', [AboutController, 'index']).as('about')
+router
+  .get('/labels/:slug', [LabelsController, 'show'])
+  .where('slug', router.matchers.slug())
+  .as('labels.show')
+
+router.get('/labels', [LabelsController, 'index']).as('labels.index')

--- a/components/fires-server/tests/request/controllers/api/labels.spec.ts
+++ b/components/fires-server/tests/request/controllers/api/labels.spec.ts
@@ -35,8 +35,8 @@ test.group('Controllers / api / labels', (group) => {
     .with<{ method: HttpMethod; endpoint: string }[]>([
       { method: 'get', endpoint: '/api/labels' },
       { method: 'post', endpoint: '/api/labels' },
-      { method: 'patch', endpoint: '/api/labels/123' },
-      { method: 'delete', endpoint: '/api/labels/123' },
+      { method: 'patch', endpoint: '/api/labels/c21450ca-8dd2-4211-b802-57937b772b20' },
+      { method: 'delete', endpoint: '/api/labels/c21450ca-8dd2-4211-b802-57937b772b20' },
     ])
     .run(async ({ assertResponse, request }, { method, endpoint }) => {
       const writeOnlyToken = await createToken(['write'])

--- a/components/fires-server/tests/request/controllers/labels.spec.ts
+++ b/components/fires-server/tests/request/controllers/labels.spec.ts
@@ -115,8 +115,6 @@ test.group('Controllers / labels', (group) => {
     assertResponse.status(response, 200)
     assertResponse.contentType(response, 'application/json; charset=utf-8')
 
-    console.log(response)
-
     const json = response.json()
 
     assert.equal(json['type'], 'Collection')


### PR DESCRIPTION
The routes file was starting to get a bit unwieldy, so this splits it up whilst still preserving the routes order that it necessary.

Also removes some logging that shouldn't have still been in place.