### PR TITLE
Fix dockerfile using outdated package version for curl

### DIFF
--- a/.changeset/small-jars-juggle.md
+++ b/.changeset/small-jars-juggle.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix dockerfile using outdated package version for curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN \
   apk add \
   tini=0.19.0-r3 \
   tzdata=2025b-r0 \
-  curl=8.12.1-r1 \
+  curl=8.14.1-r2 \
   jq=1.7.1-r0;
 
 # Configure pnpm


### PR DESCRIPTION
The pinning of package versions in the Dockerfile is apparently best practice, however, in practice it causes releases to fail because we don't know a package was updated.