### PR TITLE
Fix error with dataset changes since parameter validator

### DIFF
--- a/.changeset/yummy-readers-punch.md
+++ b/.changeset/yummy-readers-punch.md
@@ -1,0 +1,10 @@
+---
+"@fedimod/fires-server": minor
+---
+
+Fix error with dataset changes accidentally redirect
+
+I'd accidentally gotten wrong the UUID format for the genesis (first) dataset change UUID,
+it should have been `00000000-0000-7000-A000-000000000000` not `00000000-0000-7000-0000-000000000000`.
+
+This caused a validation error to be thrown which resulted in the request being redirected to the homepage.

--- a/components/fires-server/app/models/dataset_change.ts
+++ b/components/fires-server/app/models/dataset_change.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Dataset from './dataset.js'
 
-export const GENISIS_ID = '00000000-0000-7000-0000-000000000000'
+export const GENISIS_ID = '00000000-0000-7000-A000-000000000000'
 
 export type EntityKind = (typeof DatasetChange.entities)[number]
 export type ChangeTypes = (typeof DatasetChange.types)[number]

--- a/components/fires-server/app/validators/dataset_changes.ts
+++ b/components/fires-server/app/validators/dataset_changes.ts
@@ -6,6 +6,9 @@ export const datasetChangesRequestValidator = vine.compile(
       dataset_id: vine.string().uuid(),
     }),
 
-    since: vine.string().uuid().optional(),
+    since: vine
+      .string()
+      .uuid({ version: [7] })
+      .optional(),
   })
 )


### PR DESCRIPTION
I'd accidentally gotten wrong the UUID format for the genesis (first) dataset change UUID,
it should have been `00000000-0000-7000-A000-000000000000` not `00000000-0000-7000-0000-000000000000`.

This caused a validation error to be thrown which resulted in the request being redirected to the homepage.