### PR TITLE
Fix collapsed whitespace in templates

### DIFF
--- a/components/fires-server/resources/views/admin/datasets/show.edge
+++ b/components/fires-server/resources/views/admin/datasets/show.edge
@@ -56,8 +56,10 @@
           aria-describedby="url-description"
         />
       </fieldset>
-      <small class="form-hint" id="url-description">Use this <abbr title="Uniform Resource Locator">URL</abbr>when sharing
-        this label with humans.</small>
+      <small class="form-hint" id="url-description">
+        Use this <abbr title="Uniform Resource Locator">URL</abbr>
+        when sharing this label with humans.
+      </small>
       <fieldset role="group" data-copyable>
         <label for="iri">IRI:</label>
         <input
@@ -68,8 +70,10 @@
           aria-describedby="iri-description"
         />
       </fieldset>
-      <small class="form-hint" id="iri-description">Use this <abbr title="Internationalized Resource Indicator">IRI</abbr>when
-        referring to this label in datasets or software.</small>
+      <small class="form-hint" id="iri-description">
+        Use this <abbr title="Internationalized Resource Indicator">IRI</abbr>
+        when referring to this label in datasets or software.
+      </small>
     </details>
 
     <div class="d-flex">
@@ -82,8 +86,9 @@
     </div>
     @if(totalChanges != 0)
       <p>
-        There have been <a href="{{ route('admin.datasets.changes.index', { dataset_id: dataset.id }) }}">{{ totalChanges }}
-          changes</a>{{ ' ' }}over time for this dataset.
+        There have been
+        <a href="{{ route('admin.datasets.changes.index', { dataset_id: dataset.id }) }}">{{ totalChanges }} changes</a>
+        over time for this dataset.
       </p>
     @end
     @if(snapshot.length == 0)

--- a/components/fires-server/resources/views/datasets/show.edge
+++ b/components/fires-server/resources/views/datasets/show.edge
@@ -65,8 +65,8 @@
     </small>
     <p>
       To subscribe to this dataset, copy the IRI above into your server software. If your server software does not yet
-      support the <a href="{{ software.homepage }}">FIRES protocol</a>, you can request an export in the Mastodon CSV
-      formats, this will download a zip file containing both the importable files and a retractions file.
+      support the <a href="{{ software.homepage }}" target="_blank">FIRES protocol</a>, you can request an export in the
+      Mastodon CSV formats, this will download a zip file containing both the importable files and a retractions file.
     </p>
     <form method="POST" action="{{ route('datasets.export', { dataset_id: dataset.id }) }}">
       {{ csrfField() }}


### PR DESCRIPTION
This mostly affects the copyable inputs, where the whitespace was being removed by the formatter:

<img width="1264" height="279" alt="Screenshot 2025-11-14 at 05 19 43" src="https://github.com/user-attachments/assets/80ecb7aa-41b5-4ce8-9609-dc37fbe5e073" />

After:
<img width="1263" height="267" alt="Screenshot 2025-11-14 at 05 20 10" src="https://github.com/user-attachments/assets/4a27eb44-393c-495b-b75e-7817c2f7d232" />
