### PR TITLE
Fix failures when using JSON-LD profiles

### DIFF
--- a/.changeset/nine-baboons-learn.md
+++ b/.changeset/nine-baboons-learn.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Fix content negotiation when using profiles with JSON-LD

--- a/components/fires-server/package.json
+++ b/components/fires-server/package.json
@@ -84,7 +84,7 @@
     "@adonisjs/static": "^1.1.1",
     "@adonisjs/vite": "^4.0.0",
     "@picocss/pico": "^2.0.6",
-    "@thisismissem/adonisjs-respond-with": "^2.1.1",
+    "@thisismissem/adonisjs-respond-with": "^3.0.0",
     "@types/archiver": "^7.0.0",
     "@vinejs/vine": "^4.1.0",
     "archiver": "^7.0.1",

--- a/components/fires-server/tests/request/controllers/labels.spec.ts
+++ b/components/fires-server/tests/request/controllers/labels.spec.ts
@@ -166,6 +166,34 @@ test.group('Controllers / labels', (group) => {
     assert.equal(json.summary, label.summary)
   })
 
+  test('fetching the collection of labels with json-ld profile', async ({
+    assert,
+    assertResponse,
+    request,
+  }) => {
+    const label = await LabelFactory.create()
+
+    const response = await request
+      .get(`/labels`)
+      .headers({ accept: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' })
+      .end()
+
+    assertResponse.status(response, 200)
+    assertResponse.contentType(response, 'application/ld+json; charset=utf-8')
+
+    const json = response.json()
+
+    assert.equal(json['type'], 'Collection')
+    assert.equal(json.totalItems, 1)
+    assert.equal(json.updated, label.updatedAt.toFormat(XSDDateFormat))
+    assert.equal(json.items[0]['type'], 'fires:Label')
+    assert.equal(json.items[0].name, label.name)
+    assert.equal(json.items[0].summary, label.summary)
+    assert.equal(json.items[0].published, label.createdAt.toFormat(XSDDateFormat))
+    assert.equal(json.items[0].updated, label.updatedAt.toFormat(XSDDateFormat))
+    assert.notDeepInclude(json.items[0], ['deprecated'])
+  })
+
   test('fetching an individual label as html', async ({ assert, assertResponse, request }) => {
     const label = await LabelFactory.create()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^2.0.6
         version: 2.1.1
       '@thisismissem/adonisjs-respond-with':
-        specifier: ^2.1.1
-        version: 2.1.1(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@4.1.0)(argon2@0.43.1)(edge.js@6.3.0))(mime-types@3.0.1)
+        specifier: ^3.0.0
+        version: 3.0.0(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@4.1.0)(argon2@0.43.1)(edge.js@6.3.0))(mime-types@3.0.1)
       '@types/archiver':
         specifier: ^7.0.0
         version: 7.0.0
@@ -1528,8 +1528,8 @@ packages:
   '@swc/types@0.1.17':
     resolution: {integrity: sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==}
 
-  '@thisismissem/adonisjs-respond-with@2.1.1':
-    resolution: {integrity: sha512-SVsV5jZNzf37efzeB3Pd9jg8XFZho/lFxEie2Yu4GU/gWpzUVSfZ5APr37V8FHHJQs8jKR8+LiJCo4IWwDcVPw==}
+  '@thisismissem/adonisjs-respond-with@3.0.0':
+    resolution: {integrity: sha512-rszEqpSWs2PNuzSHPJj37FZA7c2luuRiJ2xeG4sv91ndUUYfjmxecLOlns6rj3qXQxAndSLC2vtCc2ee6VGK5w==}
     engines: {node: '>=20.6.0'}
     peerDependencies:
       '@adonisjs/core': ^6.2.0
@@ -6141,10 +6141,11 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@thisismissem/adonisjs-respond-with@2.1.1(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@4.1.0)(argon2@0.43.1)(edge.js@6.3.0))(mime-types@3.0.1)':
+  '@thisismissem/adonisjs-respond-with@3.0.0(@adonisjs/core@6.19.1(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@4.1.0)(argon2@0.43.1)(edge.js@6.3.0))(mime-types@3.0.1)':
     dependencies:
       '@adonisjs/core': 6.19.1(@adonisjs/assembler@7.8.2(typescript@5.7.3))(@vinejs/vine@4.1.0)(argon2@0.43.1)(edge.js@6.3.0)
       mime-types: 3.0.1
+      negotiator: 1.0.0
 
   '@tokenizer/inflate@0.2.7':
     dependencies:


### PR DESCRIPTION
Fixes an issue reported where when using a profile with JSON-LD, the FIRES server was responding incorrectly. Needed major changes to the upstream `@thisismissem/adonis-respond-with` package to support.