### PR TITLE
Migrate UUIDv7 generation to node:crypto

### DIFF
--- a/.changeset/native-uuid-generation.md
+++ b/.changeset/native-uuid-generation.md
@@ -1,0 +1,5 @@
+---
+"@fedimod/fires-server": patch
+---
+
+Replace the UUID dependency with native UUIDv7 generation.

--- a/components/fires-server/app/utils/lucid_extensions.ts
+++ b/components/fires-server/app/utils/lucid_extensions.ts
@@ -1,8 +1,7 @@
 import { column, BaseModel, beforeCreate } from '@adonisjs/lucid/orm'
 import { TypedDecorator } from '@adonisjs/lucid/types/model'
 import { Secret } from '@adonisjs/core/helpers'
-import { v7 as uuidv7 } from 'uuid'
-import type { UUIDv7 } from '#utils/uuid'
+import { uuidv7, type UUIDv7 } from '#utils/uuid'
 
 export const secretColumn = (): TypedDecorator<Secret<string>> => {
   return function (target: any, propertyKey: string) {

--- a/components/fires-server/app/utils/uuid.ts
+++ b/components/fires-server/app/utils/uuid.ts
@@ -1,1 +1,31 @@
+import * as nodeCrypto from 'node:crypto'
+
+type CryptoModule = typeof import('node:crypto')
+type CryptoModuleWithUuidV7 = CryptoModule & { randomUUIDv7?: () => string }
+
 export type UUIDv7 = string
+
+export const uuidv7 = (): UUIDv7 => {
+  const nativeUuidv7 = (nodeCrypto as CryptoModuleWithUuidV7).randomUUIDv7
+  if (nativeUuidv7) {
+    return nativeUuidv7()
+  }
+
+  const bytes = Buffer.allocUnsafe(16)
+  const timestamp = BigInt(Date.now())
+  bytes[0] = Number((timestamp >> 40n) & 0xffn)
+  bytes[1] = Number((timestamp >> 32n) & 0xffn)
+  bytes[2] = Number((timestamp >> 24n) & 0xffn)
+  bytes[3] = Number((timestamp >> 16n) & 0xffn)
+  bytes[4] = Number((timestamp >> 8n) & 0xffn)
+  bytes[5] = Number(timestamp & 0xffn)
+
+  const random = nodeCrypto.randomBytes(10)
+  bytes[6] = 0x70 | (random[0] & 0x0f)
+  bytes[7] = random[1]
+  bytes[8] = 0x80 | (random[2] & 0x3f)
+  random.copy(bytes, 9, 3)
+
+  const value = bytes.toString('hex')
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}` as UUIDv7
+}

--- a/components/fires-server/database/factories/dataset_factory.ts
+++ b/components/fires-server/database/factories/dataset_factory.ts
@@ -1,6 +1,6 @@
 import factory from '@adonisjs/lucid/factories'
 import stringHelpers from '@adonisjs/core/helpers/string'
-import { v7 as uuidv7 } from 'uuid'
+import { uuidv7 } from '#utils/uuid'
 
 import Dataset from '#models/dataset'
 

--- a/components/fires-server/database/factories/label_factory.ts
+++ b/components/fires-server/database/factories/label_factory.ts
@@ -1,6 +1,6 @@
 import factory from '@adonisjs/lucid/factories'
 import Label from '#models/label'
-import { v7 as uuidv7 } from 'uuid'
+import { uuidv7 } from '#utils/uuid'
 import { DateTime } from 'luxon'
 import { LabelTranslationFactory } from '#database/factories/label_translation_factory'
 

--- a/components/fires-server/database/factories/label_translation_factory.ts
+++ b/components/fires-server/database/factories/label_translation_factory.ts
@@ -1,6 +1,6 @@
 import factory from '@adonisjs/lucid/factories'
 import LabelTranslation from '#models/label_translation'
-import { v7 as uuidv7 } from 'uuid'
+import { uuidv7 } from '#utils/uuid'
 import { LabelFactory } from '#database/factories/label_factory'
 
 export const LabelTranslationFactory = factory

--- a/components/fires-server/package.json
+++ b/components/fires-server/package.json
@@ -103,8 +103,7 @@
     "pg-connection-string": "^2.8.5",
     "proxy-addr": "^2.0.7",
     "punycode": "^2.3.1",
-    "reflect-metadata": "^0.2.2",
-    "uuid": "^13.0.0"
+    "reflect-metadata": "^0.2.2"
   },
   "hotHook": {
     "boundaries": [

--- a/components/fires-server/tests/unit/utils/uuid.spec.ts
+++ b/components/fires-server/tests/unit/utils/uuid.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@japa/runner'
+
+import { uuidv7 } from '#utils/uuid'
+
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+test.group('uuidv7', () => {
+  test('generates valid UUIDv7 values', ({ assert }) => {
+    const value = uuidv7()
+
+    assert.match(value, UUID_V7_PATTERN)
+  })
+
+  test('embeds the current unix timestamp in milliseconds', ({ assert }) => {
+    const before = Date.now()
+    const value = uuidv7()
+    const after = Date.now()
+
+    const timestamp = Number.parseInt(value.replaceAll('-', '').slice(0, 12), 16)
+
+    assert.isAtLeast(timestamp, before)
+    assert.isAtMost(timestamp, after)
+  })
+
+  test('generates different values', ({ assert }) => {
+    const values = new Set(Array.from({ length: 100 }, () => uuidv7()))
+
+    assert.equal(values.size, 100)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
-      uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
     devDependencies:
       '@adonisjs/assembler':
         specifier: ^7.8.2
@@ -4634,10 +4631,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -9261,8 +9254,6 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
-
-  uuid@13.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
Closes #287.

## Summary
- Add a server-local UUIDv7 helper backed by node:crypto, using native randomUUIDv7 when available and a randomBytes fallback for current supported runtimes.
- Update the Lucid base model and factories to use the shared helper.
- Remove the external uuid dependency and add focused UUIDv7 coverage.

## Tests
- pnpm install --filter @fedimod/fires-server --frozen-lockfile --store-dir $PWD/.pnpm-store
- pnpm --filter @fedimod/fires-server -r format:check
- pnpm --filter @fedimod/fires-server -r lint
- pnpm --filter @fedimod/fires-server -r typecheck
- Direct UUIDv7 smoke test via ts-node-maintained

The full DB-backed test command needs the Postgres service from CI; locally it could not connect to 127.0.0.1:54321.